### PR TITLE
Fix LRIT file path parsing when path contains underscore

### DIFF
--- a/tools/lrit-img.py
+++ b/tools/lrit-img.py
@@ -220,11 +220,10 @@ def parse_fname(fpath):
     """
     Parse LRIT file name into components
     """
-    splitfilepath = fpath.split("/")
-    filepath = splitfilepath[-1]
-    split = filepath.split("_")
+
+    fname = os.path.basename(fpath)
     
-    split = fpath.split("_")
+    split = fname.split("_")
     mode = split[1]
     name = fpath.replace(args.ext, "")[:-3]
     name = "IMG_" + name.split("IMG_")[1]

--- a/tools/lrit-img.py
+++ b/tools/lrit-img.py
@@ -220,7 +220,10 @@ def parse_fname(fpath):
     """
     Parse LRIT file name into components
     """
-
+    splitfilepath = fpath.split("/")
+    filepath = splitfilepath[-1]
+    split = filepath.split("_")
+    
     split = fpath.split("_")
     mode = split[1]
     name = fpath.replace(args.ext, "")[:-3]


### PR DESCRIPTION
fix lrit file path include underlined(_),if received .lrit file path include underlined(such as /home/pi/xrit/raspberry_bak/xrit-rx//received/LRIT/20190815/FD/IMG_FD_054_IR105_20190815_090006_08.lrit ), generate img will report an error.